### PR TITLE
feat: adds event list (#2)

### DIFF
--- a/src/main/java/br/org/oficinadasmeninas/domain/event/Event.java
+++ b/src/main/java/br/org/oficinadasmeninas/domain/event/Event.java
@@ -1,0 +1,42 @@
+package br.org.oficinadasmeninas.domain.event;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public class Event {
+    private UUID id;
+    private String title;
+    private String previewImageUrl;
+    private String description;
+    private BigDecimal amount;
+    private LocalDateTime eventDate;
+    private String location;
+    private String urlToPlatform;
+
+    public Event(UUID id, String title, String previewImageUrl, String description, BigDecimal amount, LocalDateTime eventDate, String location, String urlToPlatform) {
+        this.id = id;
+        this.title = title;
+        this.previewImageUrl = previewImageUrl;
+        this.description = description;
+        this.amount = amount;
+        this.eventDate = eventDate;
+        this.location = location;
+        this.urlToPlatform = urlToPlatform;
+    }
+
+    public UUID getId() { return id; }
+
+    public String getTitle() { return title; }
+
+    public String getPreviewImageUrl() { return previewImageUrl; }
+
+    public String getDescription() { return description; }
+
+    public BigDecimal getAmount() { return amount; }
+
+    public LocalDateTime getEventDate() { return eventDate; }
+
+    public String getLocation() { return location; }
+
+    public String getUrlToPlatform() { return urlToPlatform; }
+}

--- a/src/main/java/br/org/oficinadasmeninas/domain/event/dto/EventDto.java
+++ b/src/main/java/br/org/oficinadasmeninas/domain/event/dto/EventDto.java
@@ -1,0 +1,31 @@
+package br.org.oficinadasmeninas.domain.event.dto;
+
+import br.org.oficinadasmeninas.domain.event.Event;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record EventDto(
+        UUID id,
+        String title,
+        String previewImageUrl,
+        String description,
+        BigDecimal amount,
+        LocalDateTime eventDate,
+        String location,
+        String urlToPlatform
+) {
+    public static EventDto fromEvent(Event event) {
+        return new EventDto(
+                event.getId(),
+                event.getTitle(),
+                event.getPreviewImageUrl(),
+                event.getDescription(),
+                event.getAmount(),
+                event.getEventDate(),
+                event.getLocation(),
+                event.getUrlToPlatform()
+        );
+    }
+}

--- a/src/main/java/br/org/oficinadasmeninas/domain/event/repository/IEventRepository.java
+++ b/src/main/java/br/org/oficinadasmeninas/domain/event/repository/IEventRepository.java
@@ -1,0 +1,8 @@
+package br.org.oficinadasmeninas.domain.event.repository;
+
+import br.org.oficinadasmeninas.domain.event.Event;
+import br.org.oficinadasmeninas.presentation.shared.PageDTO;
+
+public interface IEventRepository {
+    PageDTO<Event> findAll(int page, int pageSize);
+}

--- a/src/main/java/br/org/oficinadasmeninas/domain/event/service/IEventService.java
+++ b/src/main/java/br/org/oficinadasmeninas/domain/event/service/IEventService.java
@@ -1,0 +1,8 @@
+package br.org.oficinadasmeninas.domain.event.service;
+
+import br.org.oficinadasmeninas.domain.event.Event;
+import br.org.oficinadasmeninas.presentation.shared.PageDTO;
+
+public interface IEventService {
+    PageDTO<Event> findAll(int page, int pageSize);
+}

--- a/src/main/java/br/org/oficinadasmeninas/infra/event/repository/EventRepository.java
+++ b/src/main/java/br/org/oficinadasmeninas/infra/event/repository/EventRepository.java
@@ -1,0 +1,64 @@
+package br.org.oficinadasmeninas.infra.event.repository;
+
+import br.org.oficinadasmeninas.domain.event.Event;
+import br.org.oficinadasmeninas.domain.event.repository.IEventRepository;
+import br.org.oficinadasmeninas.presentation.shared.PageDTO;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository
+public class EventRepository implements IEventRepository {
+    private final JdbcTemplate jdbc;
+
+    public EventRepository(JdbcTemplate jdbc) {
+        this.jdbc = jdbc;
+    }
+
+    @Override
+    public PageDTO<Event> findAll(int page, int pageSize) {
+        String rowCountSql = "select count(*) from events";
+        int total = jdbc.queryForObject(rowCountSql, Integer.class);
+        int totalPages = Math.toIntExact((total / pageSize) + (total % pageSize == 0 ? 0 : 1));
+
+        String querySql = """
+	        select id
+	              ,title
+	              ,preview_image_url
+                  ,description
+                  ,amount
+                  ,event_date
+                  ,location
+                  ,url_to_platform
+	        from events
+	        order BY id
+	       limit ? offset ?
+	    """;
+
+        List<Event> events = jdbc.query(
+                querySql,
+                this::mapRow,
+                pageSize,
+                page
+        );
+
+        return new PageDTO<>(events, total, totalPages);
+    }
+
+    private Event mapRow(ResultSet rs, int rowNum) throws SQLException {
+        return new Event(
+                rs.getObject("id", java.util.UUID.class),
+                rs.getString("title"),
+                rs.getString("preview_image_url"),
+                rs.getString("description"),
+                rs.getBigDecimal("amount"),
+                rs.getObject("event_date", LocalDateTime.class),
+                rs.getString("location"),
+                rs.getString("url_to_platform")
+        );
+    }
+}

--- a/src/main/java/br/org/oficinadasmeninas/infra/event/service/EventService.java
+++ b/src/main/java/br/org/oficinadasmeninas/infra/event/service/EventService.java
@@ -1,0 +1,25 @@
+package br.org.oficinadasmeninas.infra.event.service;
+
+import br.org.oficinadasmeninas.domain.event.Event;
+import br.org.oficinadasmeninas.domain.event.repository.IEventRepository;
+import br.org.oficinadasmeninas.domain.event.service.IEventService;
+import br.org.oficinadasmeninas.presentation.shared.PageDTO;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
+import org.springframework.stereotype.Service;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Service
+public class EventService implements IEventService {
+    private final IEventRepository eventRepository;
+
+    public EventService(IEventRepository eventRepository) {
+        this.eventRepository = eventRepository;
+    }
+
+    public PageDTO<Event> findAll(@RequestParam @PositiveOrZero int page,
+                                  @RequestParam @Positive @Max(100) int pageSize){
+        return eventRepository.findAll(page, pageSize);
+    }
+}

--- a/src/main/java/br/org/oficinadasmeninas/presentation/controller/EventController.java
+++ b/src/main/java/br/org/oficinadasmeninas/presentation/controller/EventController.java
@@ -1,0 +1,27 @@
+package br.org.oficinadasmeninas.presentation.controller;
+
+import br.org.oficinadasmeninas.domain.event.Event;
+import br.org.oficinadasmeninas.domain.event.service.IEventService;
+import br.org.oficinadasmeninas.presentation.shared.PageDTO;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/events")
+public class EventController {
+    private final IEventService eventService;
+
+    public EventController(IEventService eventService) {
+        this.eventService = eventService;
+    }
+
+    @GetMapping()
+    @ResponseStatus(HttpStatus.OK)
+    public PageDTO<Event> findAll(@RequestParam(defaultValue = "0") @PositiveOrZero int page,
+                                  @RequestParam(defaultValue = "10") @Positive @Max(100) int pageSize) {
+        return eventService.findAll(page, pageSize);
+    }
+}

--- a/src/main/resources/data/events.sql
+++ b/src/main/resources/data/events.sql
@@ -1,0 +1,25 @@
+create table events (
+                        id uuid primary key
+    ,title varchar(500)
+    ,preview_image_url varchar(4000)
+    ,description varchar(500)
+    ,amount numeric(15, 2)
+    ,event_date TIMESTAMP WITHOUT TIME ZONE
+    ,location varchar(200)
+    ,url_to_platform varchar(4000)
+);
+
+alter table events alter column amount type numeric(15, 2)
+
+insert into events
+values (gen_random_uuid(),
+        'Pokemon GO da Oficina',
+        'pokemon-go.png',
+        'Neste sábado 06/09 estaremos todos caçando pokemon na praça são roque! Venha conosco nessa jornada!',
+        2563.90,
+        '2025-09-06 13:00:00',
+        'Praça São Roque/Araraquara',
+        'https://seu-evento-online.com.br/oficina/pokemon-go');
+
+select *
+from events;


### PR DESCRIPTION
This pull request introduces a complete backend feature for managing and retrieving paginated event data. It includes the domain model, DTO, repository, service, controller, and database schema for events. The main focus is to enable clients to fetch paginated lists of events via a REST API endpoint.

**Event Domain and Data Transfer:**

* Added the `Event` domain model representing event properties such as ID, title, description, amount, date, location, and platform URL (`Event.java`).
* Introduced `EventDto` for transferring event data, with a static method to convert from the domain model (`EventDto.java`).

**Persistence and Data Access:**

* Created the database schema for events, including sample data insertion (`events.sql`).
* Implemented the repository interface (`IEventRepository.java`) and its JDBC-based implementation (`EventRepository.java`) for paginated event retrieval. [[1]](diffhunk://#diff-57c607e458ee2faa41b15d2f42cbebffb58469c422e5de77504a449149cea987R1-R8) [[2]](diffhunk://#diff-b3b1937d359c9a04a133b230b56d4867d1c38c1db970e94809a2567d90a1720cR1-R64)

**Service and API Layer:**

* Defined the service interface (`IEventService.java`) and its implementation (`EventService.java`) to handle business logic and input validation for event pagination. [[1]](diffhunk://#diff-30dc391b03ebf62d256ee63e961f287503a18f9ce045d4391ec8d5687f67c843R1-R8) [[2]](diffhunk://#diff-0c4930689fb53618297530bb9d6da38454bd1d954c57e54b3d4fc69ad7156c87R1-R25)
* Added the REST controller (`EventController.java`) exposing the `/api/events` endpoint for fetching paginated event lists.