### PR TITLE
fix: allow cors

### DIFF
--- a/src/main/java/br/org/oficinadasmeninas/infra/config/SecurityConfig.java
+++ b/src/main/java/br/org/oficinadasmeninas/infra/config/SecurityConfig.java
@@ -70,6 +70,7 @@ public class SecurityConfig {
 	@Bean
 	SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
 		http.csrf(AbstractHttpConfigurer::disable)
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
 				.sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 				.authorizeHttpRequests(auth -> auth.anyRequest().permitAll()).httpBasic(Customizer.withDefaults())
 				.formLogin(AbstractHttpConfigurer::disable);


### PR DESCRIPTION
This pull request updates the security configuration to enable CORS with a custom configuration source. The main change is the addition of CORS support to the security filter chain.

**Security configuration update:**

* Enabled CORS in the `securityFilterChain` method by specifying a custom configuration source using `.cors(cors -> cors.configurationSource(corsConfigurationSource()))` in `SecurityConfig.java`.