### PR TITLE
47 cria endpoint delete events e adiciona filtro nos demais metodos 

### DIFF
--- a/src/main/java/br/org/oficinadasmeninas/domain/event/Event.java
+++ b/src/main/java/br/org/oficinadasmeninas/domain/event/Event.java
@@ -5,6 +5,7 @@ import java.util.UUID;
 
 public class Event {
     private UUID id;
+    private Boolean isActive;
     private String title;
     private String previewImageUrl;
     private String partnersImageUrl;
@@ -35,6 +36,10 @@ public class Event {
     public UUID getId() { return id; }
 
     public void setId(UUID id) { this.id = id; }
+
+    public Boolean isActive() { return isActive; }
+
+    public void setIsActive(Boolean isActive) { this.isActive = isActive; }
 
     public String getTitle() { return title; }
 

--- a/src/main/java/br/org/oficinadasmeninas/domain/event/dto/UpdateEventDto.java
+++ b/src/main/java/br/org/oficinadasmeninas/domain/event/dto/UpdateEventDto.java
@@ -1,5 +1,6 @@
 package br.org.oficinadasmeninas.domain.event.dto;
 
+import br.org.oficinadasmeninas.domain.event.Event;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -13,6 +14,8 @@ public record UpdateEventDto(
         MultipartFile previewImage,
 
         MultipartFile partnersImage,
+
+        Boolean isActive,
 
         @NotNull(message = "O id do evento é obrigatório.")
         UUID id,
@@ -32,4 +35,18 @@ public record UpdateEventDto(
 
         @NotBlank(message = "A url para a plataforma do evento é obrigatória")
         String urlToPlatform
-) { }
+) {
+        public static UpdateEventDto fromEvent(Event event) {
+                return new UpdateEventDto(
+                        null,
+                        null,
+                        event.isActive(),
+                        event.getId(),
+                        event.getTitle(),
+                        event.getDescription(),
+                        event.getEventDate(),
+                        event.getLocation(),
+                        event.getUrlToPlatform()
+                );
+        }
+}

--- a/src/main/java/br/org/oficinadasmeninas/domain/event/service/IEventService.java
+++ b/src/main/java/br/org/oficinadasmeninas/domain/event/service/IEventService.java
@@ -14,4 +14,5 @@ public interface IEventService {
     Event findById(UUID id) throws Exception;
     Event createEvent(CreateEventDto eventDto) throws IOException;
     Event updateEvent(UUID id, UpdateEventDto updateEventDto) throws Exception;
+    void deleteEvent(UUID id) throws Exception;
 }

--- a/src/main/java/br/org/oficinadasmeninas/infra/event/repository/EventQueryBuilder.java
+++ b/src/main/java/br/org/oficinadasmeninas/infra/event/repository/EventQueryBuilder.java
@@ -5,6 +5,7 @@ public class EventQueryBuilder {
         SELECT id, title, preview_image_url, partners_image_url, description, event_date, location, url_to_platform
         FROM EVENTS
         WHERE id = ?
+          AND isActive
     """;
 
     public static final String SELECT_COUNT = """
@@ -20,6 +21,7 @@ public class EventQueryBuilder {
               AND (location ILIKE COALESCE('%' || ? || '%', location))
               AND event_date BETWEEN COALESCE(?, event_date)
                              AND COALESCE(?, event_date)
+              AND isActive
             ORDER BY event_date DESC
             LIMIT ? OFFSET ?;
     """;
@@ -37,7 +39,8 @@ public class EventQueryBuilder {
             description = ?,
             event_date = ?,
             location = ?,
-            url_to_platform = ?
+            url_to_platform = ?,
+            isActive = ?
         WHERE id = ?
     """;
 }

--- a/src/main/java/br/org/oficinadasmeninas/infra/event/repository/EventRepository.java
+++ b/src/main/java/br/org/oficinadasmeninas/infra/event/repository/EventRepository.java
@@ -87,6 +87,7 @@ public class EventRepository implements IEventRepository {
                 Timestamp.valueOf(updateEventDto.eventDate()),
                 updateEventDto.location(),
                 updateEventDto.urlToPlatform(),
+                updateEventDto.isActive() == null || updateEventDto.isActive(),
                 updateEventDto.id());
     }
 

--- a/src/main/java/br/org/oficinadasmeninas/infra/event/service/EventService.java
+++ b/src/main/java/br/org/oficinadasmeninas/infra/event/service/EventService.java
@@ -74,6 +74,15 @@ public class EventService implements IEventService {
         );
     }
 
+    public void deleteEvent(UUID id) {
+        var event = eventRepository.getEventById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Evento não encontrado: " + id));
+
+        event.setIsActive(false);
+
+        eventRepository.updateEvent(UpdateEventDto.fromEvent(event), event.getPreviewImageUrl(), event.getPartnersImageUrl());
+    }
+
     private String uploadMultipartFile(MultipartFile file) throws IOException {
         if (file == null || file.isEmpty())
             return null;

--- a/src/main/java/br/org/oficinadasmeninas/presentation/controller/EventController.java
+++ b/src/main/java/br/org/oficinadasmeninas/presentation/controller/EventController.java
@@ -64,4 +64,10 @@ public class EventController {
 
         return eventService.updateEvent(id, updateEventDto);
     }
+
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deleteEvent(@PathVariable UUID id) throws Exception {
+        eventService.deleteEvent(id);
+    }
 }


### PR DESCRIPTION
This pull request introduces support for soft deletion of events by adding an `isActive` flag to the `Event` entity and updating the service, repository, and controller layers to use this flag. Events are now marked as inactive instead of being permanently deleted, and queries have been updated to only return active events.

**Soft Deletion and isActive Flag:**

* Added `isActive` field to the `Event` class, along with getter and setter methods. [[1]](diffhunk://#diff-2b8b607b614174084ed0972d8427a2c867375a597e3d014583b12b321b8ea65fR8) [[2]](diffhunk://#diff-2b8b607b614174084ed0972d8427a2c867375a597e3d014583b12b321b8ea65fR40-R43)
* Updated `UpdateEventDto` to include the `isActive` field and a static `fromEvent` method for mapping. [[1]](diffhunk://#diff-a95d15f07f93aa182faba099f6ed476a822403afd53a1623ace889e0ef0885edR3) [[2]](diffhunk://#diff-a95d15f07f93aa182faba099f6ed476a822403afd53a1623ace889e0ef0885edR18-R19) [[3]](diffhunk://#diff-a95d15f07f93aa182faba099f6ed476a822403afd53a1623ace889e0ef0885edL35-R52)

**Repository and Query Updates:**

* Modified SQL queries in `EventQueryBuilder` to filter by `isActive`, ensuring only active events are selected or counted, and updated the update statement to handle the `isActive` field. [[1]](diffhunk://#diff-a1813f24646f4d1e4116eeddaf3506966e9c24f3d4ef56d287fd3f04f88603d7R8) [[2]](diffhunk://#diff-a1813f24646f4d1e4116eeddaf3506966e9c24f3d4ef56d287fd3f04f88603d7R24) [[3]](diffhunk://#diff-a1813f24646f4d1e4116eeddaf3506966e9c24f3d4ef56d287fd3f04f88603d7L40-R43)
* Updated `EventRepository` to set the `isActive` value when updating events.

**Service and Controller Changes:**

* Added a `deleteEvent` method to `IEventService` and implemented it in `EventService` to perform a soft delete by setting `isActive` to `false`. [[1]](diffhunk://#diff-30dc391b03ebf62d256ee63e961f287503a18f9ce045d4391ec8d5687f67c843R17) [[2]](diffhunk://#diff-0c4930689fb53618297530bb9d6da38454bd1d954c57e54b3d4fc69ad7156c87R77-R85)
* Added a new `@DeleteMapping` endpoint in `EventController` to expose the soft delete functionality via the API.