### PR TITLE
hotfix: corrige semantica do event sql query builder pos merge conflict

### DIFF
--- a/src/main/java/br/org/oficinadasmeninas/infra/event/repository/EventQueryBuilder.java
+++ b/src/main/java/br/org/oficinadasmeninas/infra/event/repository/EventQueryBuilder.java
@@ -7,6 +7,7 @@ public class EventQueryBuilder {
         WHERE (
                 (unaccent(title) ILIKE COALESCE('%' || unaccent(?) || '%', title))
                 OR (unaccent(location) ILIKE COALESCE('%' || unaccent(?) || '%', location))
+          )
           AND description ILIKE COALESCE('%' || ? || '%', description)
           AND event_date BETWEEN COALESCE(?, event_date)
           AND COALESCE(?, event_date)


### PR DESCRIPTION
This pull request makes a minor adjustment to the SQL query used in `EventQueryBuilder.java`. The change clarifies the grouping of conditions in the WHERE clause, which helps ensure the intended logical precedence for filtering events.

- Query logic update:
  * Added a closing parenthesis after the OR conditions on `title` and `location` to clearly group them together in the WHERE clause of the SQL query in `EventQueryBuilder.java`.
[Copilot is generating a summary...]