### PR TITLE
hot fix: trazer 0 ao invés de null na query

### DIFF
--- a/src/main/java/br/org/oficinadasmeninas/infra/statistics/repository/StatisticsQueryBuilder.java
+++ b/src/main/java/br/org/oficinadasmeninas/infra/statistics/repository/StatisticsQueryBuilder.java
@@ -16,10 +16,10 @@ public class StatisticsQueryBuilder {
             """;
 
     public static final String GET_DONATION_TYPE_DISTRIBUTION = """
-            SELECT ROUND(SUM(CASE WHEN d.sponsorship_id IS NULL THEN COALESCE(d.value_liquid, 0) END)::numeric, 2) AS one_time_donation_liquid
-                  ,ROUND(SUM(CASE WHEN d.sponsorship_id IS NULL THEN d.value END)::numeric, 2) AS one_time_donation
-                  ,ROUND(SUM(CASE WHEN d.sponsorship_id IS NOT NULL THEN COALESCE(d.value_liquid, 0) END)::numeric, 2) AS recurring_donation_liquid
-                  ,ROUND(SUM(CASE WHEN d.sponsorship_id IS NOT NULL THEN d.value END)::numeric, 2) AS recurring_donation
+            SELECT ROUND(SUM(CASE WHEN d.sponsorship_id IS NULL THEN COALESCE(d.value_liquid, 0) ELSE 0 END)::numeric, 2) AS one_time_donation_liquid
+                  ,ROUND(SUM(CASE WHEN d.sponsorship_id IS NULL THEN d.value ELSE 0 END)::numeric, 2) AS one_time_donation
+                  ,ROUND(SUM(CASE WHEN d.sponsorship_id IS NOT NULL THEN COALESCE(d.value_liquid, 0) ELSE 0 END)::numeric, 2) AS recurring_donation_liquid
+                  ,ROUND(SUM(CASE WHEN d.sponsorship_id IS NOT NULL THEN d.value ELSE 0 END)::numeric, 2) AS recurring_donation
                   ,ROUND(SUM(COALESCE(d.value_liquid, 0))::numeric, 2) AS total_donation_liquid
                   ,ROUND(SUM(d.value)::numeric, 2) AS total_donation
             FROM donation d


### PR DESCRIPTION
This pull request updates the SQL query responsible for calculating donation type distributions in `StatisticsQueryBuilder.java`. The main change improves the accuracy of aggregation by ensuring that only relevant rows contribute to each donation type sum, preventing nulls from affecting the results.

**Donation calculation improvements:**

* Updated the SQL query in `GET_DONATION_TYPE_DISTRIBUTION` to use `ELSE 0` in each `CASE` statement, ensuring that only matching rows are summed for each donation type and non-matching rows contribute zero. This prevents null values from being summed and improves the accuracy of one-time and recurring donation calculations.