### PR TITLE
fix: adicionado validação de caracter especial no nome do usuário

### DIFF
--- a/src/main/java/br/org/oficinadasmeninas/domain/user/dto/CreateUserDto.java
+++ b/src/main/java/br/org/oficinadasmeninas/domain/user/dto/CreateUserDto.java
@@ -2,12 +2,14 @@ package br.org.oficinadasmeninas.domain.user.dto;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 public class CreateUserDto {
 
 	@NotBlank(message = "O nome é obrigatório")
-	@Size(max = 255, message = "O nome deve ter no máximo 255 caracteres")
+	@Size(max = 120, message = "O nome deve ter no máximo 120 caracteres")
+    @Pattern(regexp = "^[\\p{L} ]+$", message = "O nome deve conter apenas letras e acentos")
 	private String name;
 
 	@NotBlank(message = "O email é obrigatório")


### PR DESCRIPTION
This pull request updates the validation rules for the `name` field in the `CreateUserDto` class to enforce stricter requirements on user input.

User data validation improvements:

* Reduced the maximum allowed length for the `name` field from 255 to 120 characters in `CreateUserDto`.
* Added a regular expression pattern to ensure the `name` field contains only letters (including accented characters) and spaces in `CreateUserDto`.